### PR TITLE
TCS breakaway (2/2): build independence — generate map rasters, no TCS install needed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,11 @@
 ###############################################################################
 * text=auto
 
+# Binary map assets — never line-ending-normalize (would corrupt the embedded DDS rasters).
+*.dds binary
+*.tga binary
+*.png binary
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Contributions are welcome. Please read this before opening a pull request.
 
 **Prerequisites:**
 - [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
-- CK3 installed with [Total Conversion Sandbox](https://steamcommunity.com/sharedfiles/filedetails/?id=2524797018)
+- CK3 installed
 - An Azgaar export to test with (or use the included test data)
 
 **Build:**

--- a/ConsoleUI/Program.cs
+++ b/ConsoleUI/Program.cs
@@ -610,20 +610,18 @@ internal class Program
         Console.WriteLine("Welcome! I need a few things before I can convert your map.");
 
         var ck3 = ResolveCk3Directory();
-        var tcs = ResolveTcsDirectory();
         var modsDir = ResolveModsDirectory();
         var modName = PromptModName();
 
         Settings.Instance = new Settings
         {
             ModsDirectory = modsDir,
-            TotalConversionSandboxPath = tcs,
             Ck3Directory = ck3,
             ModName = modName,
         };
         SettingsManager.Save();
 
-        // Step 5/5 — Azgaar exports. PromptForInputDirectory writes its results
+        // Step 4/4 — Azgaar exports. PromptForInputDirectory writes its results
         // into Settings.Instance and saves again.
         PromptForInputDirectory();
 
@@ -636,7 +634,7 @@ internal class Program
     private static string ResolveCk3Directory()
     {
         Console.WriteLine();
-        Console.WriteLine("──[ 1/5 ]── Crusader Kings III install");
+        Console.WriteLine("──[ 1/4 ]── Crusader Kings III install");
 
         var found = SettingsManager.TryFindCk3InstallRoot();
         if (found != null)
@@ -666,115 +664,6 @@ internal class Program
                 return path;
             Console.WriteLine("   That folder doesn't contain a 'game' subdirectory. Try again.");
         }
-    }
-
-    private static string ResolveTcsDirectory()
-    {
-        Console.WriteLine();
-        Console.WriteLine("──[ 2/5 ]── Total Conversion Sandbox mod");
-
-        var candidates = SettingsManager.TryFindTotalConversionSandbox();
-
-        if (candidates.Count == 1)
-        {
-            var c = candidates[0];
-            var versionSuffix = c.Version != null ? $"  (v{c.Version})" : "";
-            Console.WriteLine($"   Found:");
-            Console.WriteLine($"     {c.Name}{versionSuffix}");
-            Console.WriteLine($"     {c.Path}");
-            Console.Write("   Use this? [Y/n]: ");
-            if (ReadConfirm(defaultIsYes: true))
-                return c.Path;
-            Console.WriteLine("   Paste a different TCS folder path (drag-and-drop supported):");
-            Console.Write("   Path (or press Enter to exit): ");
-            var raw = (Console.ReadLine() ?? "").Trim();
-            if (string.IsNullOrWhiteSpace(raw)) Exit();
-            return PromptForValidTcsPath(StripSurroundingQuotes(raw));
-        }
-
-        if (candidates.Count > 1)
-        {
-            Console.WriteLine($"   Found {candidates.Count} candidates in your Steam workshop:");
-            for (int i = 0; i < candidates.Count; i++)
-            {
-                var c = candidates[i];
-                var versionSuffix = c.Version != null ? $"  (v{c.Version})" : "";
-                Console.WriteLine($"     [{i + 1}] {c.Name}{versionSuffix}");
-                Console.WriteLine($"         {c.Path}");
-            }
-            Console.Write($"   Pick [1-{candidates.Count}], paste a different path, or press Enter to exit: ");
-            var raw = (Console.ReadLine() ?? "").Trim();
-            if (int.TryParse(raw, out var idx) && idx >= 1 && idx <= candidates.Count)
-                return candidates[idx - 1].Path;
-            if (string.IsNullOrWhiteSpace(raw))
-            {
-                Console.WriteLine("   Exiting setup.");
-                Exit();
-            }
-            return PromptForValidTcsPath(StripSurroundingQuotes(raw));
-        }
-
-        // 0 candidates — most common real failure for a brand-new user
-        Console.WriteLine("   I couldn't find TCS in your Steam workshop folder.");
-        Console.WriteLine();
-        Console.WriteLine("   TCS is a required dependency. To install it:");
-        Console.WriteLine("     1. Open Steam -> Crusader Kings III -> Workshop tab");
-        Console.WriteLine("     2. Search \"Total Conversion Sandbox\" and subscribe");
-        Console.WriteLine("     3. Let Steam download it (~50 MB)");
-        Console.WriteLine("     4. Re-run me");
-        Console.WriteLine();
-        Console.WriteLine("   Or paste a path here if you have a copy somewhere else");
-        Console.WriteLine("   (you can drag the folder from Explorer into this window):");
-        Console.Write("   Path (or press Enter to exit and subscribe first): ");
-        var paste = (Console.ReadLine() ?? "").Trim();
-        if (string.IsNullOrWhiteSpace(paste))
-        {
-            Console.WriteLine("   Exiting. Re-run me after subscribing to TCS.");
-            Exit();
-        }
-        return PromptForValidTcsPath(StripSurroundingQuotes(paste));
-    }
-
-    private static string PromptForValidTcsPath(string initial)
-    {
-        var path = initial;
-        while (true)
-        {
-            if (ValidateTcsPath(path, out var reason))
-                return path;
-            Console.WriteLine($"   {reason}");
-            Console.Write("   TCS path (or press Enter to exit): ");
-            var raw = (Console.ReadLine() ?? "").Trim();
-            if (string.IsNullOrWhiteSpace(raw))
-                Exit();
-            path = StripSurroundingQuotes(raw);
-        }
-    }
-
-    private static bool ValidateTcsPath(string path, out string reason)
-    {
-        if (!Directory.Exists(path))
-        {
-            reason = $"Folder doesn't exist: {path}";
-            return false;
-        }
-        var descriptorPath = Converter.Helper.GetPath(path, "descriptor.mod");
-        if (!File.Exists(descriptorPath))
-        {
-            reason = $"No descriptor.mod inside {path} — is this the mod's root folder?";
-            return false;
-        }
-        string content;
-        try { content = File.ReadAllText(descriptorPath); }
-        catch (Exception ex) { reason = $"Couldn't read descriptor.mod: {ex.Message}"; return false; }
-
-        if (content.IndexOf("Total Conversion Sandbox", StringComparison.OrdinalIgnoreCase) < 0)
-        {
-            reason = "descriptor.mod doesn't mention 'Total Conversion Sandbox' — wrong mod?";
-            return false;
-        }
-        reason = "";
-        return true;
     }
 
     private static void PromptForInputDirectory()
@@ -840,7 +729,7 @@ internal class Program
     private static string ResolveModsDirectory()
     {
         Console.WriteLine();
-        Console.WriteLine("──[ 3/5 ]── Where to put the converted mod");
+        Console.WriteLine("──[ 2/4 ]── Where to put the converted mod");
         Console.WriteLine($"   CK3's standard mod folder (where the launcher looks for local mods):");
         Console.WriteLine($"     {SettingsManager.DefaultModsDirectory}");
         Console.WriteLine("   Your mod will be created as a subfolder there.");
@@ -910,7 +799,7 @@ internal class Program
     private static string PromptModName()
     {
         Console.WriteLine();
-        Console.WriteLine("──[ 4/5 ]── What should we name your mod?");
+        Console.WriteLine("──[ 3/4 ]── What should we name your mod?");
         Console.Write("   ModName [MyAzgaarMod]: ");
         var raw = (Console.ReadLine() ?? "").Trim();
         return string.IsNullOrWhiteSpace(raw) ? "MyAzgaarMod" : raw;

--- a/ConsoleUI/release-README.txt
+++ b/ConsoleUI/release-README.txt
@@ -1,20 +1,17 @@
 AzgaarToCK3 — Quickstart
 ========================
 
-1. Subscribe to "Total Conversion Sandbox" on the Steam Workshop
-   (Crusader Kings III → Workshop tab). Wait for Steam to download it.
-
-2. Generate a map at https://azgaar.github.io/Fantasy-Map-Generator/
+1. Generate a map at https://azgaar.github.io/Fantasy-Map-Generator/
    Export THREE files: Full data .json, Cells .geojson, Rivers .geojson.
 
-3. Run ConsoleUI.exe. The first time, it walks you through a 3-step setup
-   (CK3 location, TCS location, mod name). It writes a settings.json
-   next to itself; edit that file later to change anything.
+2. Run ConsoleUI.exe. The first time, it walks you through a short setup
+   (CK3 location, mods folder, mod name, and your Azgaar exports). It writes
+   a settings.json next to itself; edit that file later to change anything.
 
-4. Tell the converter where your Azgaar exports are. Easiest:
+3. To convert different exports later, point the converter at them:
        ConsoleUI.exe --input-dir "C:\path\to\your\exports"
    Or set "InputDirectory" in settings.json and just double-click.
 
-5. Activate the generated mod in the CK3 launcher alongside TCS.
+4. Enable the generated mod in the CK3 launcher and play.
 
 Docs and issue tracker: https://github.com/MnTronslien/AzgaarToCK3

--- a/Converter/Converter.csproj
+++ b/Converter/Converter.csproj
@@ -25,6 +25,9 @@
     <EmbeddedResource Include="Lemur\Assets\frontend_main.info">
       <LogicalName>Converter.Lemur.Assets.frontend_main.info</LogicalName>
     </EmbeddedResource>
+    <!-- Map-render rasters (colormap, surround mask/fade, water) are NOT bundled — they're generated
+         as flat solids at convert time by DdsWriter (see MapRenderAssetsWriter / TerrainMaskWriter),
+         so the build needs no TCS and the repo carries no large DDS. -->
   </ItemGroup>
 
   <ItemGroup>

--- a/Converter/Lemur/ConversionManager.cs
+++ b/Converter/Lemur/ConversionManager.cs
@@ -250,7 +250,7 @@ namespace Converter.Lemur
             // hide the bookmark portrait; its render crashes the main menu on a generated map
             await FrontendGuiWriter.Write(Settings.OutputDirectory);
             // surround_map / water / vegetation, so the standalone map shows no vanilla geography
-            await MapRenderAssetsWriter.Write(Settings.Instance.TotalConversionSandboxPath, Settings.OutputDirectory);
+            await MapRenderAssetsWriter.Write(Settings.Instance.Ck3Directory, Settings.OutputDirectory);
             if (w.ProvinceTerrain)
             {
                 using var _ = OperationTimer.Start("Writing province terrain");
@@ -264,12 +264,12 @@ namespace Converter.Lemur
             if (w.TerrainMasks)
             {
                 var terrainMasks = TerrainMaskPreparer.Prepare(map);
-                await TerrainMaskWriter.Write(terrainMasks, map, Settings.Instance.TotalConversionSandboxPath, Settings.OutputDirectory);
+                await TerrainMaskWriter.Write(terrainMasks, map, Settings.Instance.Ck3Directory, Settings.OutputDirectory);
             }
             if (w.Flatmap)
                 await FlatmapWriter.Write(map, Settings.Instance.AzgaarSvgPath, Settings.OutputDirectory);
             if (w.MapStaticFiles)
-                await StaticFilesWriter.Write(Settings.Instance.TotalConversionSandboxPath, Settings.OutputDirectory);
+                await StaticFilesWriter.Write(Settings.OutputDirectory);
             if (w.Religion)
             {
                 using var _ = OperationTimer.Start("Writing religion files (copy from CK3)");

--- a/Converter/Lemur/DdsWriter.cs
+++ b/Converter/Lemur/DdsWriter.cs
@@ -1,11 +1,8 @@
 namespace Converter.Lemur;
 
 /// <summary>
-/// Writes a solid-colour, uncompressed 32-bit BGRA <c>.dds</c> from code — no shipped binary, no
-/// image library. Used for the map-render rasters that only need to be a single uniform value to
-/// override vanilla (colormap, surround mask/fade, water flow/foam/colour). The values match what
-/// TCS shipped (sampled — every pixel identical), so the in-game look is unchanged while the build
-/// stays TCS-free and the repo carries no large DDS. Enrichment (real detail) is a logged follow-up.
+/// Writes a solid-colour, uncompressed 32-bit BGRA <c>.dds</c> from code (no binary, no image
+/// library) for map-render rasters that only need a uniform value to override vanilla.
 /// </summary>
 public static class DdsWriter
 {

--- a/Converter/Lemur/DdsWriter.cs
+++ b/Converter/Lemur/DdsWriter.cs
@@ -1,0 +1,56 @@
+namespace Converter.Lemur;
+
+/// <summary>
+/// Writes a solid-colour, uncompressed 32-bit BGRA <c>.dds</c> from code — no shipped binary, no
+/// image library. Used for the map-render rasters that only need to be a single uniform value to
+/// override vanilla (colormap, surround mask/fade, water flow/foam/colour). The values match what
+/// TCS shipped (sampled — every pixel identical), so the in-game look is unchanged while the build
+/// stays TCS-free and the repo carries no large DDS. Enrichment (real detail) is a logged follow-up.
+/// </summary>
+public static class DdsWriter
+{
+    // DDS header flag constants (see Microsoft DDS_HEADER / DDS_PIXELFORMAT docs).
+    private const uint DDSD_CAPS = 0x1, DDSD_HEIGHT = 0x2, DDSD_WIDTH = 0x4, DDSD_PIXELFORMAT = 0x1000, DDSD_PITCH = 0x8;
+    private const uint DDPF_ALPHAPIXELS = 0x1, DDPF_RGB = 0x40;
+    private const uint DDSCAPS_TEXTURE = 0x1000;
+
+    /// <summary>Write a width×height image where every pixel is (r,g,b,a), as an uncompressed BGRA DDS.</summary>
+    public static async Task WriteSolidAsync(string path, int width, int height, byte r, byte g, byte b, byte a)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await using var fs = File.Create(path);
+        using var w = new BinaryWriter(fs);
+
+        w.Write(0x20534444u);                                              // "DDS " magic
+        w.Write(124u);                                                     // dwSize
+        w.Write(DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT | DDSD_PITCH);
+        w.Write((uint)height);
+        w.Write((uint)width);
+        w.Write((uint)(width * 4));                                        // dwPitchOrLinearSize (bytes/row)
+        w.Write(0u);                                                       // depth
+        w.Write(0u);                                                       // mipMapCount (0 = single)
+        for (int i = 0; i < 11; i++) w.Write(0u);                          // dwReserved1[11]
+        // DDS_PIXELFORMAT (32 bytes) — A8R8G8B8 (BGRA in memory).
+        w.Write(32u);
+        w.Write(DDPF_RGB | DDPF_ALPHAPIXELS);
+        w.Write(0u);                                                       // fourCC (0 = uncompressed)
+        w.Write(32u);                                                      // RGBBitCount
+        w.Write(0x00FF0000u);                                              // R mask
+        w.Write(0x0000FF00u);                                              // G mask
+        w.Write(0x000000FFu);                                              // B mask
+        w.Write(0xFF000000u);                                              // A mask
+        w.Write(DDSCAPS_TEXTURE);                                          // caps
+        w.Write(0u); w.Write(0u); w.Write(0u);                             // caps2/3/4
+        w.Write(0u);                                                       // dwReserved2
+
+        // Pixel data, one uniform row reused for every scanline. Memory order is B,G,R,A.
+        var row = new byte[width * 4];
+        for (int x = 0; x < width; x++)
+        {
+            int o = x * 4;
+            row[o] = b; row[o + 1] = g; row[o + 2] = r; row[o + 3] = a;
+        }
+        for (int y = 0; y < height; y++)
+            fs.Write(row, 0, row.Length);
+    }
+}

--- a/Converter/Lemur/EmbeddedAssets.cs
+++ b/Converter/Lemur/EmbeddedAssets.cs
@@ -4,8 +4,7 @@ namespace Converter.Lemur;
 
 /// <summary>
 /// Extracts files embedded in the Converter assembly (see Converter.csproj EmbeddedResource items)
-/// to disk. Used to ship static mod assets — frontend_main.gui override and the map-render rasters
-/// (colormap / surround) — without depending on a TCS or CK3 install at build time.
+/// to disk, so static mod assets ship without a TCS or CK3 install at build time.
 /// </summary>
 internal static class EmbeddedAssets
 {

--- a/Converter/Lemur/EmbeddedAssets.cs
+++ b/Converter/Lemur/EmbeddedAssets.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+
+namespace Converter.Lemur;
+
+/// <summary>
+/// Extracts files embedded in the Converter assembly (see Converter.csproj EmbeddedResource items)
+/// to disk. Used to ship static mod assets — frontend_main.gui override and the map-render rasters
+/// (colormap / surround) — without depending on a TCS or CK3 install at build time.
+/// </summary>
+internal static class EmbeddedAssets
+{
+    public static async Task ExtractAsync(string resourceName, string destPath)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        await using var stream = asm.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{resourceName}' not found — check Converter.csproj EmbeddedResource items.");
+        Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
+        await using var dest = File.Create(destPath);
+        await stream.CopyToAsync(dest);
+    }
+}

--- a/Converter/Lemur/Writers/MapRenderAssetsWriter.cs
+++ b/Converter/Lemur/Writers/MapRenderAssetsWriter.cs
@@ -1,56 +1,50 @@
 namespace Converter.Lemur.Writers;
 
 /// <summary>
-/// Ships the map-render rasters that suppress vanilla bleed-through on the standalone map:
-///   * gfx/map/surround_map/  — decorative terrain outside the grid (vanilla shows real geography)
-///   * gfx/map/water/          — water colour/flow/foam (vanilla's gives wrong sea topology+colour)
-///   * gfx/map/map_object_data/generated/ — vegetation generators (replace_path'd by ModDescriptorWriter)
-/// surround_map + water override vanilla by filename (no replace_path needed).
-///
-/// Copied verbatim from the local TCS install at convert time; the runtime mod stays TCS-free.
-/// Phase B will synthesize these so the build needs no TCS. See bugs/BUG_tcs-breakaway-bootcrash.md.
+/// Writes the rasters that keep the standalone (TCS-free) map from showing vanilla content:
+/// surround_map (terrain outside the grid — tile copied from CK3, mask/fade generated flat), water
+/// (flow/foam/colour, generated flat), and an empty map_object_data/generated (no vanilla trees).
+/// Flat solids come from <see cref="DdsWriter"/> at the uniform values TCS used; enrich later (notes-for-later.md).
 /// </summary>
 public static class MapRenderAssetsWriter
 {
-    // Directories copied verbatim from <tcs>/gfx/map/ into <mod>/gfx/map/.
-    private static readonly string[] AssetDirs =
+    // (relative output path, width, height, r, g, b, a) — flat-solid rasters generated in code.
+    private static readonly (string Rel, int W, int H, byte R, byte G, byte B, byte A)[] SolidRasters =
     [
-        Path.Combine("surround_map"),
-        Path.Combine("water"),
-        Path.Combine("map_object_data", "generated"),
+        ("surround_map/surround_mask.dds",          4096, 2048,   0,   0,   0, 255),
+        ("surround_map/surround_fade.dds",          1024,  512, 255, 255,   0, 255),
+        ("water/flowmap.dds",                       2048, 1024, 126, 130, 255, 255),
+        ("water/foam_map.dds",                      1024,  512,   0,   1,   0, 255),
+        ("water/watercolor_rgb_waterspec_a.dds",    4096, 2048,  13,  27,  32, 255),
     ];
 
-    public static async Task Write(string tcsSandboxPath, string outputDirectory)
+    public static async Task Write(string ck3Directory, string outputDirectory)
     {
         using var _ = OperationTimer.Start("Writing map render assets");
 
-        if (string.IsNullOrWhiteSpace(tcsSandboxPath) || !Directory.Exists(tcsSandboxPath))
-        {
-            Logger.Warning("MapRenderAssetsWriter: TCS path unavailable — skipping surround_map/water/generated " +
-                           "(map will show vanilla bleed around edges / sea until Phase B synthesizes these).");
-            return;
-        }
+        foreach (var s in SolidRasters)
+            await DdsWriter.WriteSolidAsync(
+                Helper.GetPath(outputDirectory, "gfx", "map", s.Rel.Replace('/', Path.DirectorySeparatorChar)),
+                s.W, s.H, s.R, s.G, s.B, s.A);
 
+        // surround_tile is byte-identical to vanilla — copy it from the CK3 install (not generated).
+        var tileSrc = Helper.GetPath(ck3Directory, "game", "gfx", "map", "surround_map", "surround_tile.dds");
         var copied = 0;
-        foreach (var rel in AssetDirs)
+        if (File.Exists(tileSrc))
         {
-            var srcDir = Helper.GetPath(tcsSandboxPath, "gfx", "map", rel);
-            if (!Directory.Exists(srcDir))
-            {
-                Logger.Warning($"MapRenderAssetsWriter: '{rel}' not found in TCS install — skipping.");
-                continue;
-            }
-
-            var dstDir = Helper.GetPath(outputDirectory, "gfx", "map", rel);
-            Directory.CreateDirectory(dstDir);
-            foreach (var src in Directory.EnumerateFiles(srcDir))
-            {
-                File.Copy(src, Helper.GetPath(dstDir, Path.GetFileName(src)), overwrite: true);
-                copied++;
-            }
+            var dst = Helper.GetPath(outputDirectory, "gfx", "map", "surround_map", "surround_tile.dds");
+            Directory.CreateDirectory(Path.GetDirectoryName(dst)!);
+            File.Copy(tileSrc, dst, overwrite: true);
+            copied = 1;
+        }
+        else
+        {
+            Logger.Warning("MapRenderAssetsWriter: surround_tile.dds not found in CK3 install — skipping.");
         }
 
-        Logger.Info($"Copied {copied} map render assets from TCS (surround_map + water + vegetation generators) [stopgap]");
-        await Task.CompletedTask;
+        // gfx/map/map_object_data/generated — replace_path'd + shipped EMPTY (no vanilla vegetation).
+        Directory.CreateDirectory(Helper.GetPath(outputDirectory, "gfx", "map", "map_object_data", "generated"));
+
+        Logger.Info($"Wrote map render assets: {SolidRasters.Length} generated solids (surround mask/fade + water) + {copied} CK3 copy (surround_tile) + empty generated [no TCS, no shipped DDS]");
     }
 }

--- a/Converter/Lemur/Writers/StaticFilesWriter.cs
+++ b/Converter/Lemur/Writers/StaticFilesWriter.cs
@@ -4,7 +4,7 @@ namespace Converter.Lemur.Writers;
 
 public static class StaticFilesWriter
 {
-    public static async Task Write(string tcsSandboxPath, string outputDirectory)
+    public static async Task Write(string outputDirectory)
     {
         using var _ = OperationTimer.Start("Writing static files");
         var mapDataDir = Helper.GetPath(outputDirectory, "map_data");

--- a/Converter/Lemur/Writers/TerrainMaskWriter.cs
+++ b/Converter/Lemur/Writers/TerrainMaskWriter.cs
@@ -31,9 +31,7 @@ public static class TerrainMaskWriter
             Height = L.Map.MapHeight,
         };
 
-        // Supplement with a blank mask for every CK3 mask filename we don't explicitly set, so
-        // vanilla's full-resolution masks don't leak through at the wrong scale. Filenames come from
-        // the CK3 install (same set TCS shipped) — no TCS dependency.
+        // Blank-fill every CK3 mask filename we don't explicitly set, so vanilla's masks don't leak through at the wrong scale.
         var baseMasksDir = Helper.GetPath(ck3Directory, "game", "gfx", "map", "terrain", "masks");
         var covered = masks.Select(m => m.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
         var blanks = Directory.Exists(baseMasksDir)
@@ -104,10 +102,8 @@ public static class TerrainMaskWriter
 
     private static async Task WriteColormapAsync(string terrainDir)
     {
-        // Generate a flat colormap (every pixel mid-grey 132,132,132) at map/4 resolution. Its only
-        // job is to override vanilla's real-world-geography colormap so our map isn't Earth-tinted;
-        // 132 is the exact uniform value TCS shipped, so the look is unchanged. No TCS, no shipped
-        // binary. Enrichment (biome-driven tint) is a logged follow-up — see notes-for-later.md.
+        // Flat mid-grey (132,132,132) colormap at map/4 resolution, to override vanilla's
+        // real-world-geography colormap so our map isn't Earth-tinted.
         await DdsWriter.WriteSolidAsync(
             Helper.GetPath(terrainDir, "colormap.dds"),
             L.Map.MapWidth / 4, L.Map.MapHeight / 4,

--- a/Converter/Lemur/Writers/TerrainMaskWriter.cs
+++ b/Converter/Lemur/Writers/TerrainMaskWriter.cs
@@ -14,7 +14,7 @@ public static class TerrainMaskWriter
     public static async Task Write(
         IReadOnlyList<TerrainMaskEntry> masks,
         L.Map map,
-        string tcsSandboxPath,
+        string ck3Directory,
         string outputDirectory)
     {
         using var _ = OperationTimer.Start("Writing terrain mask files");
@@ -31,9 +31,10 @@ public static class TerrainMaskWriter
             Height = L.Map.MapHeight,
         };
 
-        // Supplement with blank masks for every TCS mask filename we don't explicitly set.
-        // Without this, TCS files at 9216×4608 leak through at wrong scale.
-        var baseMasksDir = Helper.GetPath(tcsSandboxPath, "gfx", "map", "terrain", "masks");
+        // Supplement with a blank mask for every CK3 mask filename we don't explicitly set, so
+        // vanilla's full-resolution masks don't leak through at the wrong scale. Filenames come from
+        // the CK3 install (same set TCS shipped) — no TCS dependency.
+        var baseMasksDir = Helper.GetPath(ck3Directory, "game", "gfx", "map", "terrain", "masks");
         var covered = masks.Select(m => m.FileName).ToHashSet(StringComparer.OrdinalIgnoreCase);
         var blanks = Directory.Exists(baseMasksDir)
             ? Directory.EnumerateFiles(baseMasksDir, "*.png")
@@ -60,8 +61,8 @@ public static class TerrainMaskWriter
         // Run all 5 groups concurrently — they write to different files, no shared mutable state.
         await Task.WhenAll(
             Task.WhenAll(allMasks.Select(entry => WriteBiomeMask(entry, masksDir, readSettings, map, blankPath))),
-            WriteColormapAsync(tcsSandboxPath, terrainDir),
-            WriteMasksGenAsync(tcsSandboxPath, terrainDir, blankPath),
+            WriteColormapAsync(terrainDir),
+            WriteMasksGenAsync(ck3Directory, terrainDir, blankPath),
             Task.Run(async () =>
             {
                 // map.HeightmapPixels/F are populated by HeightmapWriter if it ran first.
@@ -101,37 +102,21 @@ public static class TerrainMaskWriter
         await image.WriteAsync(dst);
     }
 
-    private static async Task WriteColormapAsync(string tcsSandboxPath, string terrainDir)
+    private static async Task WriteColormapAsync(string terrainDir)
     {
-        var src = Helper.GetPath(tcsSandboxPath, "gfx", "map", "terrain", "colormap.dds");
-        var dst = Helper.GetPath(terrainDir, "colormap.dds");
-
-        // Cache key: source path + last-write time + output dimensions → stable per TCS version.
-        var srcInfo = new FileInfo(src);
-        var cacheKey = $"{src}|{srcInfo.LastWriteTimeUtc.Ticks}|{L.Map.MapWidth / 4}|{L.Map.MapHeight / 4}";
-        var cacheHash = Convert.ToHexString(
-            System.Security.Cryptography.SHA256.HashData(
-                System.Text.Encoding.UTF8.GetBytes(cacheKey)))[..16];
-        var cachePath = Helper.GetPath(CacheDir, $"colormap_{cacheHash}.dds");
-
-        if (!File.Exists(cachePath))
-        {
-            using var img = new MagickImage(src);
-            img.Resize(L.Map.MapWidth / 4, L.Map.MapHeight / 4);
-            await img.WriteAsync(cachePath);
-            Logger.Debug($"Cached resized colormap.dds → {cachePath}");
-        }
-        else
-        {
-            Logger.Debug("colormap.dds cache hit — skipping 163MB load");
-        }
-
-        File.Copy(cachePath, dst, overwrite: true);
+        // Generate a flat colormap (every pixel mid-grey 132,132,132) at map/4 resolution. Its only
+        // job is to override vanilla's real-world-geography colormap so our map isn't Earth-tinted;
+        // 132 is the exact uniform value TCS shipped, so the look is unchanged. No TCS, no shipped
+        // binary. Enrichment (biome-driven tint) is a logged follow-up — see notes-for-later.md.
+        await DdsWriter.WriteSolidAsync(
+            Helper.GetPath(terrainDir, "colormap.dds"),
+            L.Map.MapWidth / 4, L.Map.MapHeight / 4,
+            r: 132, g: 132, b: 132, a: 255);
     }
 
-    private static async Task WriteMasksGenAsync(string tcsSandboxPath, string terrainDir, string blankPath)
+    private static async Task WriteMasksGenAsync(string ck3Directory, string terrainDir, string blankPath)
     {
-        var srcDir = Helper.GetPath(tcsSandboxPath, "gfx", "map", "terrain", "masks_gen");
+        var srcDir = Helper.GetPath(ck3Directory, "game", "gfx", "map", "terrain", "masks_gen");
         if (!Directory.Exists(srcDir)) return;
 
         var dstDir = Helper.GetPath(terrainDir, "masks_gen");

--- a/Converter/ModManager.cs
+++ b/Converter/ModManager.cs
@@ -4,10 +4,8 @@ public static class ModManager
 {
     public static async Task CreateMod()
     {
-        // Ensure the mod output folder exists. We no longer seed it from TCS — the Lemur writers
-        // produce a complete, self-contained mod, and ModDescriptorWriter writes the descriptor +
-        // launcher .mod with the correct supported_version. (Previously this copied the entire TCS
-        // directory as a baseline; that was the last build-time TCS dependency and is now gone.)
+        // Ensure the mod output folder exists. The Lemur writers produce a complete, self-contained
+        // mod, so this no longer seeds the folder from TCS.
         Directory.CreateDirectory(Helper.GetPath(Settings.Instance.ModsDirectory, Settings.Instance.ModName));
         await Task.CompletedTask;
     }

--- a/Converter/ModManager.cs
+++ b/Converter/ModManager.cs
@@ -1,35 +1,15 @@
-using Microsoft.VisualBasic.FileIO;
-
 namespace Converter;
 
 public static class ModManager
 {
     public static async Task CreateMod()
     {
-        // CK3's mod folder may not exist yet on a fresh CK3 install (or if the user
-        // pointed ModsDirectory at a custom location). File.WriteAllTextAsync won't
-        // create missing parents, so we make sure the directory exists first.
-        Directory.CreateDirectory(Settings.Instance.ModsDirectory);
-
-        var outsideDescriptor = $@"version=""1.0""
-tags={{
-	""Total Conversion""
-}}
-name=""{Settings.Instance.ModName}""
-supported_version=""1.12.4""
-path=""mod/{Settings.Instance.ModName}""";
-
-        await File.WriteAllTextAsync(Helper.GetPath(Settings.Instance.ModsDirectory, $"{Settings.Instance.ModName}.mod"), outsideDescriptor);
-
-        FileSystem.CopyDirectory(Settings.Instance.TotalConversionSandboxPath, Helper.GetPath(Settings.Instance.ModsDirectory, Settings.Instance.ModName), true);
-
-        var insideDescriptor = $@"version=""1.0""
-tags={{
-	""Total Conversion""
-}}
-name=""{Settings.Instance.ModName}""
-supported_version=""1.12.4""";
-        await File.WriteAllTextAsync(Helper.GetPath(Settings.Instance.ModsDirectory, Settings.Instance.ModName, "descriptor.mod"), insideDescriptor);
+        // Ensure the mod output folder exists. We no longer seed it from TCS — the Lemur writers
+        // produce a complete, self-contained mod, and ModDescriptorWriter writes the descriptor +
+        // launcher .mod with the correct supported_version. (Previously this copied the entire TCS
+        // directory as a baseline; that was the last build-time TCS dependency and is now gone.)
+        Directory.CreateDirectory(Helper.GetPath(Settings.Instance.ModsDirectory, Settings.Instance.ModName));
+        await Task.CompletedTask;
     }
     public static bool DoesModExist()
     {

--- a/Converter/SettingsManager.cs
+++ b/Converter/SettingsManager.cs
@@ -11,9 +11,7 @@ public class Settings
 {
     public required string ModsDirectory { get; init; }
     public required string Ck3Directory { get; init; }
-    // Optional: nothing in the converter reads this any more (the build is TCS-free as of the
-    // breakaway). Kept nullable so old settings.json files still deserialize and the first-run
-    // setup can leave it unset. Safe to remove once no settings.json references it.
+    // Unused by the converter; kept nullable so old settings.json files still deserialize.
     public string? TotalConversionSandboxPath { get; init; }
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     public string InputJsonPath { get; set; }

--- a/Converter/SettingsManager.cs
+++ b/Converter/SettingsManager.cs
@@ -11,7 +11,10 @@ public class Settings
 {
     public required string ModsDirectory { get; init; }
     public required string Ck3Directory { get; init; }
-    public required string TotalConversionSandboxPath { get; init; }
+    // Optional: nothing in the converter reads this any more (the build is TCS-free as of the
+    // breakaway). Kept nullable so old settings.json files still deserialize and the first-run
+    // setup can leave it unset. Safe to remove once no settings.json references it.
+    public string? TotalConversionSandboxPath { get; init; }
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     public string InputJsonPath { get; set; }
     public string InputGeojsonPath { get; set; }

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,6 @@ See the [Usage Guide](docs/USAGE.md) for CLI options, seed control, and debug ou
 
 ## Requirements
 - Crusader Kings III `1.19.*` (newest at the time of writing, but any version should do)
-- [Total Conversion Sandbox](https://steamcommunity.com/sharedfiles/filedetails/?id=2524797018) mod (Steam Workshop) (Working to make this dependency obsolete.) — the current TCS is built for CK3 1.18, but it is still the correct mod to subscribe to and load for the converter to work.
 - [Azgaar's Fantasy Map Generator](https://azgaar.github.io/Fantasy-Map-Generator/) — default settings work out of the box. An [alternate build](https://pryvyd9.github.io/Fantasy-Map-Generator/) produces better sea zones; if you use it, **do not use its built-in "Export for CK3" button** — that targets a different converter.
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,7 +22,6 @@ Explicit paths (`-j`, `-g`, `-r`) always override directory auto-detection.
 |-----|-----|------|---------|-------------|
 | `ModsDirectory` | — | string | *(required)* | CK3 mods folder |
 | `Ck3Directory` | — | string | *(required)* | CK3 install root |
-| `TotalConversionSandboxPath` | — | string | *(required)* | Path to TCS mod folder |
 | `ModName` | — | string | *(required)* | Name of the generated mod |
 | `AutoWipeOutput` | `--no-wipe` | bool | `true` | Wipe mod folder before converting |
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Usage Guide
 
-Assumes you have CK3, the [Total Conversion Sandbox](https://steamcommunity.com/sharedfiles/filedetails/?id=2524797018) mod, and [.NET 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) installed.
+Assumes you have CK3 and [.NET 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) installed.
 
 ---
 
@@ -49,7 +49,7 @@ For a full list of supported arguments see usage with:
 
 1. Launch CK3
 2. Open the **Mods** menu → **Playsets**
-3. Create a playset containing **Total Conversion Sandbox** and your generated mod
+3. Create a playset containing your generated mod
 4. Launch
 
 ---


### PR DESCRIPTION
**Stacked on #25** — review/merge that first. This PR is based on `feature/tcs-breakaway`, so its diff is only the build-time delta.

## What
The converter no longer reads anything from a TCS install at build time. **TCS can be uninstalled from the machine entirely** and the converter still produces a complete, playable mod.

## How
- Mask filenames + `surround_tile` now sourced from the **CK3 install** (always present), not TCS.
- **Map rasters generated in code** (`DdsWriter`): sampling showed every TCS map raster is a single uniform colour, so we emit each as a flat uncompressed DDS at the exact value TCS used — colormap, surround mask/fade, and water flow/foam/colour. No shipped binaries, no image library.
- `ModManager.CreateMod` no longer copies the entire TCS directory as a mod seed (it was vestigial — the writers already produce a complete mod).
- `TotalConversionSandboxPath` is now optional, and first-run setup drops the sandbox prompt.

## Testing
Converter runs to completion with `TotalConversionSandboxPath` pointed at a bogus path and a freshly-deleted mod folder. The resulting mod boots and plays; in-game look is unchanged (generated raster values match the sampled TCS values exactly).

## ⚠️ Merge note
**Please squash-merge.** The interim commit `33a09c0` carries a ~15 MB bundled-DDS blob that is superseded by the in-code generation; squashing keeps it out of `develop`.

## Follow-ups (not blocking)
- Enrich the colormap with a biome-driven tint (currently a flat override).
- Add biome-appropriate vegetation (the `generated/` folder ships empty for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
