### PR TITLE
Route the start date through a single Map.StartDate field

### DIFF
--- a/Converter/Lemur/CharacterFactory.cs
+++ b/Converter/Lemur/CharacterFactory.cs
@@ -254,6 +254,9 @@ public static class CharacterFactory
             Converter.Settings.Instance.Seed!.Value, map.Characters.Count, culture.AzgaarId));
         var name = pool[rng.Next(pool.Length)];
 
-        return new Character(culture, faith, map.StartDate.Year - RulerAgeOffset, name);
+        // Floor at 0: CK3 dates cannot be below year 0, and a low start date could push the
+        // birth year negative (StartDate itself is already floored, but 0 - RulerAgeOffset isn't).
+        var birthYear = Math.Max(0, map.StartDate.Year - RulerAgeOffset);
+        return new Character(culture, faith, birthYear, name);
     }
 }

--- a/Converter/Lemur/CharacterFactory.cs
+++ b/Converter/Lemur/CharacterFactory.cs
@@ -15,6 +15,11 @@ using Converter.Lemur.Entities;
 /// </summary>
 public static class CharacterFactory
 {
+    // Generated rulers are born this many years before the game-start date. A placeholder until the
+    // age bell-curve (notes-for-later.md) replaces it with a per-character age; relocated here from
+    // the old hardcoded Character.BirthYear = 1033 so birth years track Map.StartDate.
+    private const int RulerAgeOffset = 33;
+
     public static void CreateAndAssignAll(Map map)
     {
         var claimed = new HashSet<County>();
@@ -249,6 +254,6 @@ public static class CharacterFactory
             Converter.Settings.Instance.Seed!.Value, map.Characters.Count, culture.AzgaarId));
         var name = pool[rng.Next(pool.Length)];
 
-        return new Character(culture, faith, name);
+        return new Character(culture, faith, map.StartDate.Year - RulerAgeOffset, name);
     }
 }

--- a/Converter/Lemur/ConversionManager.cs
+++ b/Converter/Lemur/ConversionManager.cs
@@ -97,7 +97,7 @@ namespace Converter.Lemur
                 $"{cellDist.CultureCellCounts.Count} cultures have at least one land cell.");
 
             map.Faiths = FaithManager.Build(map.JsonMap.pack.religions, cellDist.ReligionCellCounts);
-            map.Cultures = CultureManager.Build(map.JsonMap.pack.cultures, Settings.Instance.Seed!.Value);
+            map.Cultures = CultureManager.Build(map.JsonMap.pack.cultures, Settings.Instance.Seed!.Value, map.StartDate.Year);
 
             // ✅ Visualization checkpoint 1: Raw cells
             await ImageUtility.DrawCells(map.Cells!.Values.ToList(), map);

--- a/Converter/Lemur/CultureManager.cs
+++ b/Converter/Lemur/CultureManager.cs
@@ -118,8 +118,6 @@ public static class CultureManager
 
         // Pass 5: assign creation dates
         // Foundational cultures (no parents) are ancient — no created date.
-        // Depth 1 (derived from foundational): 867.1.1
-        // Depth 2+ (derived from derived): 1000.1.1
         AssignCreationDates(cultures, result, startYear);
 
         var sb = new System.Text.StringBuilder($"Assigned pillars to {result.Count} cultures (traditions assigned later by CultureTraditionAssigner).");

--- a/Converter/Lemur/CultureManager.cs
+++ b/Converter/Lemur/CultureManager.cs
@@ -310,7 +310,9 @@ public static class CultureManager
             }
             // depth maxDepth → startYear - stepYears
             // depth 1        → startYear - (maxDepth * stepYears)
-            int year = startYear - ((maxDepth - d + 1) * stepYears);
+            // Floor at 0: a low start date (or a deep tree) can push this negative, and CK3
+            // dates cannot be below year 0.
+            int year = Math.Max(0, startYear - ((maxDepth - d + 1) * stepYears));
             culture.CreationDate = $"{year}.1.1";
         }
     }

--- a/Converter/Lemur/CultureManager.cs
+++ b/Converter/Lemur/CultureManager.cs
@@ -72,7 +72,7 @@ public static class CultureManager
         ];
     }
 
-    public static Dictionary<int, Culture> Build(AzgaarCulture[] cultures, int seed)
+    public static Dictionary<int, Culture> Build(AzgaarCulture[] cultures, int seed, int startYear)
     {
         Converter.Lemur.Logger.Section("Building cultures");
         var result = new Dictionary<int, Culture>();
@@ -120,7 +120,7 @@ public static class CultureManager
         // Foundational cultures (no parents) are ancient — no created date.
         // Depth 1 (derived from foundational): 867.1.1
         // Depth 2+ (derived from derived): 1000.1.1
-        AssignCreationDates(cultures, result);
+        AssignCreationDates(cultures, result, startYear);
 
         var sb = new System.Text.StringBuilder($"Assigned pillars to {result.Count} cultures (traditions assigned later by CultureTraditionAssigner).");
         foreach (var c in result.Values.OrderBy(c => c.AzgaarId))
@@ -245,7 +245,7 @@ public static class CultureManager
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────
 
-    private static void AssignCreationDates(AzgaarCulture[] cultures, Dictionary<int, Culture> result)
+    private static void AssignCreationDates(AzgaarCulture[] cultures, Dictionary<int, Culture> result, int startYear)
     {
         var parentIds = new Dictionary<int, int[]>();
         foreach (var azc in cultures)
@@ -297,9 +297,8 @@ public static class CultureManager
             if (!depth.ContainsKey(id))
                 depth[id] = 1;
 
-        // Invert: deepest culture is created 100 years before start date,
+        // Invert: deepest culture is created 100 years before start date (startYear),
         // each level up adds another 100 years. Foundational (depth 0) = no date.
-        const int startYear = 1066;
         const int stepYears = 100;
         int maxDepth = depth.Values.DefaultIfEmpty(0).Max();
 

--- a/Converter/Lemur/Entities/Character.cs
+++ b/Converter/Lemur/Entities/Character.cs
@@ -11,12 +11,12 @@ public class Character
     public int BirthYear { get; }
     public List<ITitle> HeldTitles { get; } = new();
 
-    public Character(Culture culture, Faith faith, string? name = null)
+    public Character(Culture culture, Faith faith, int birthYear, string? name = null)
     {
         Id = $"lemur_{++_counter}";
         Name = name;
         Culture = culture;
         Faith = faith;
-        BirthYear = 1033;
+        BirthYear = birthYear;
     }
 }

--- a/Converter/Lemur/Entities/Duchy.cs
+++ b/Converter/Lemur/Entities/Duchy.cs
@@ -11,7 +11,7 @@ namespace Converter.Lemur.Entities
         /// CK3 government for this duchy, resolved once from its Azgaar state's form/formName
         /// by <see cref="Converter.Lemur.Governments.GovernmentResolver"/>. Null when the resolver
         /// hasn't run yet or there is no Azgaar state to read from (e.g. wasteland-derived duchies
-        /// with AzgaarStateId = 0). Read by TitleHistoryWriter when emitting the duchy's 1066.1.1 block.
+        /// with AzgaarStateId = 0). Read by TitleHistoryWriter when emitting the duchy's <see cref="Map.StartDate"/> block.
         /// </summary>
         public Ck3Government? Government { get; set; }
 

--- a/Converter/Lemur/Entities/Interfaces.cs
+++ b/Converter/Lemur/Entities/Interfaces.cs
@@ -50,7 +50,7 @@ namespace Converter.Lemur.Entities
         /// <summary>
         /// CK3 government for this title. Resolved by <see cref="Converter.Lemur.Governments.GovernmentResolver"/>;
         /// populated for Kingdom and Duchy in the MVP, null elsewhere. Read by TitleHistoryWriter when
-        /// emitting the title's 1066.1.1 history block — null means "no government clause emitted".
+        /// emitting the title's <see cref="Map.StartDate"/> history block — null means "no government clause emitted".
         /// </summary>
         public Ck3Government? Government { get; set; }
 

--- a/Converter/Lemur/Entities/Map.cs
+++ b/Converter/Lemur/Entities/Map.cs
@@ -23,6 +23,13 @@ namespace Converter.Lemur.Entities
         public required AzgaarJsonMap JsonMap { get; set; }
         public required Settings Settings { get; set; }
 
+        /// <summary>
+        /// CK3 game-start date — single source of truth for every dated emission (title history,
+        /// bookmark, character births, culture creation dates). World data, not a setting; a future
+        /// loader will populate it from the Azgaar export. Default 1066.1.1.
+        /// </summary>
+        public StartDate StartDate { get; set; } = new(1066, 1, 1);
+
         public Dictionary<int, Cell>? Cells { get; set; }
         public Dictionary<int, Burg>? Burgs { get; set; }
 

--- a/Converter/Lemur/Entities/StartDate.cs
+++ b/Converter/Lemur/Entities/StartDate.cs
@@ -1,0 +1,12 @@
+namespace Converter.Lemur.Entities;
+
+/// <summary>
+/// CK3 game-start date — the single source of truth for every dated emission (title history,
+/// bookmark, character births, culture creation dates). Lives on <see cref="Map"/> because it is
+/// world data, not a user setting; a future loader will populate it from the Azgaar export.
+/// Default 1066.1.1 reproduces pre-rewire output byte-for-byte.
+/// </summary>
+public readonly record struct StartDate(int Year, int Month, int Day)
+{
+    public override string ToString() => $"{Year}.{Month}.{Day}";
+}

--- a/Converter/Lemur/Entities/StartDate.cs
+++ b/Converter/Lemur/Entities/StartDate.cs
@@ -8,5 +8,11 @@ namespace Converter.Lemur.Entities;
 /// </summary>
 public readonly record struct StartDate(int Year, int Month, int Day)
 {
+    // CK3 dates cannot be below year 0 (a .info file in the engine data spells this out).
+    // Floor defensively at the source so a future negative year — e.g. a bad Azgaar export —
+    // can never emit an invalid date. Derived dates (births, culture creation) are floored at
+    // their own emit sites, since they subtract from this and can go negative on their own.
+    public int Year { get; init; } = Math.Max(0, Year);
+
     public override string ToString() => $"{Year}.{Month}.{Day}";
 }

--- a/Converter/Lemur/Writers/BookmarkWriter.cs
+++ b/Converter/Lemur/Writers/BookmarkWriter.cs
@@ -9,9 +9,6 @@ namespace Converter.Lemur.Writers;
 /// </summary>
 public static class BookmarkWriter
 {
-    // Must match TitleHistoryWriter.StartDate — the bookmark date is when holders are assigned.
-    private const string StartDate = "1066.1.1";
-    private const string GroupKey = "bm_group_1066";
     private const string BookmarkKey = "bm_lemur";
 
     // How many of the largest realms to surface as selectable bookmark characters.
@@ -20,6 +17,11 @@ public static class BookmarkWriter
     public static async Task Write(L.Map map, string outputDirectory)
     {
         using var _ = OperationTimer.Start("Writing start bookmark");
+
+        // The bookmark date is when holders are assigned — single source of truth on Map.StartDate
+        // (the same date TitleHistoryWriter emits on every title-history block).
+        var startDate = map.StartDate.ToString();
+        var groupKey = $"bm_group_{map.StartDate.Year}";
 
         // Largest held realms first; kingdoms are the top playable tier (empires have no holder).
         var rulers = map.Kingdoms
@@ -36,15 +38,15 @@ public static class BookmarkWriter
         Directory.CreateDirectory(groupsDir);
         await File.WriteAllTextAsync(
             Helper.GetPath(groupsDir, "00_bookmark_groups.txt"),
-            $"{GroupKey} = {{\n\tdefault_start_date = {StartDate}\n}}\n",
+            $"{groupKey} = {{\n\tdefault_start_date = {startDate}\n}}\n",
             Helper.Utf8Bom);
 
         // --- bookmark + per-ruler character blocks ---
         var sb = new System.Text.StringBuilder();
         sb.AppendLine($"{BookmarkKey} = {{");
-        sb.AppendLine($"\tstart_date = {StartDate}");
+        sb.AppendLine($"\tstart_date = {startDate}");
         sb.AppendLine("\tis_playable = yes");
-        sb.AppendLine($"\tgroup = {GroupKey}");
+        sb.AppendLine($"\tgroup = {groupKey}");
         sb.AppendLine();
         sb.AppendLine("\tweight = { value = 100 }");
 

--- a/Converter/Lemur/Writers/TitleHistoryWriter.cs
+++ b/Converter/Lemur/Writers/TitleHistoryWriter.cs
@@ -4,10 +4,9 @@ namespace Converter.Lemur.Writers;
 
 public static class TitleHistoryWriter
 {
-    private const string StartDate = "1066.1.1";
-
     public static async Task Write(L.Map map, string outputDirectory)
     {
+        var startDate = map.StartDate.ToString();
         var sb = new System.Text.StringBuilder();
 
         foreach (var empire in map.Empires!)
@@ -15,7 +14,7 @@ public static class TitleHistoryWriter
             // Emperor: assigned only for diplomacy-driven empires (CharacterFactory's empire pass). Holderless
             // culture/religion shells emit nothing. Government inherited from the suzerain kingdom.
             if (empire.Holder != null)
-                sb.AppendLine(TitleEntry(empire.Ck3_Id(), empire.Holder.Id, liege: null, governmentKey: empire.Government?.Key));
+                sb.AppendLine(TitleEntry(startDate, empire.Ck3_Id(), empire.Holder.Id, liege: null, governmentKey: empire.Government?.Key));
 
             foreach (var kingdom in empire.Kingdoms)
             {
@@ -25,13 +24,13 @@ public static class TitleHistoryWriter
                 if (kingdom.Holder != null)
                 {
                     var kLiege = kingdom.DeFactoLiege is { } kl && kl.Holder != kingdom.Holder ? kl.Ck3_Id() : null;
-                    sb.AppendLine(TitleEntry(kingdom.Ck3_Id(), kingdom.Holder.Id, liege: kLiege, governmentKey: kingdom.Government?.Key));
+                    sb.AppendLine(TitleEntry(startDate, kingdom.Ck3_Id(), kingdom.Holder.Id, liege: kLiege, governmentKey: kingdom.Government?.Key));
                 }
 
                 foreach (var duchy in kingdom.Duchies)
                 {
                     if (duchy.Holder != null)
-                        sb.AppendLine(TitleEntry(duchy.Ck3_Id(), duchy.Holder.Id, duchy.DeFactoLiege?.Ck3_Id(), governmentKey: duchy.Government?.Key));
+                        sb.AppendLine(TitleEntry(startDate, duchy.Ck3_Id(), duchy.Holder.Id, duchy.DeFactoLiege?.Ck3_Id(), governmentKey: duchy.Government?.Key));
 
                     // Always write county liege — even without a holder.
                     // CK3 will auto-spawn a count and route them to the correct liege.
@@ -39,6 +38,7 @@ public static class TitleHistoryWriter
                     // counties to the first titled holder it finds (often the wrong king).
                     foreach (var county in duchy.Counties)
                         sb.AppendLine(TitleEntry(
+                            startDate,
                             county.Ck3_Id(),
                             county.Holder?.Id,
                             county.DeFactoLiege!.Ck3_Id(),
@@ -62,12 +62,12 @@ public static class TitleHistoryWriter
     /// `e_japan.txt` for nomad and japan_feudal). Development levels are emitted on counties only
     /// (from the 1.3.0 feature/county-development feature).
     /// </summary>
-    private static string TitleEntry(string titleId, string? holderId, string? liege, string? governmentKey = null, int? development = null)
+    private static string TitleEntry(string startDate, string titleId, string? holderId, string? liege, string? governmentKey = null, int? development = null)
     {
         var holderClause = holderId != null ? $" holder = {holderId}" : "";
         var liegeClause = liege != null ? $" liege = {liege}" : "";
         var govClause = governmentKey != null ? $" government = {governmentKey}" : "";
         var devClause = development.HasValue ? $" change_development_level = {development.Value}" : "";
-        return $"{titleId} = {{ {StartDate} = {{{holderClause}{liegeClause}{govClause}{devClause} }} }}";
+        return $"{titleId} = {{ {startDate} = {{{holderClause}{liegeClause}{govClause}{devClause} }} }}";
     }
 }


### PR DESCRIPTION
Step one of making the CK3 start date dynamic (`PLAN_start_date.md`): collapse the scattered hardcoded date literals into a single source of truth on the `Map` object, so a later feature can deserialize the date from Azgaar with a one-line loader change. **Behaviour-neutral rewire — the default stays 1066.1.1.**

The start date lives on `Map` (world data), **not** `Settings`, because the intent is to read it from the Azgaar export, not expose a hand-editable knob.

## What changed
- **New `StartDate` value type** (`readonly record struct` Year/Month/Day, `ToString() → "Y.M.D"`).
- **`Map.StartDate`** property, default `1066.1.1` — the single source of truth.
- Dropped the duplicated `const StartDate = "1066.1.1"` from **`TitleHistoryWriter`** and **`BookmarkWriter`** (they carried a hand-sync comment); both now read `map.StartDate`. Bookmark group key is now `bm_group_{year}`.
- Dropped the hardcoded `BirthYear = 1033`; birth year now derives as `StartDate.Year - RulerAgeOffset` (33), a named placeholder the future age bell-curve will replace.
- Threaded `startYear` through the static `CultureManager.Build → AssignCreationDates` (the one non-trivial change — it had no `Map` access).
- **Negative-date precaution:** a `.info` file in the engine data documents that CK3 dates cannot be below year 0. Floored at every emit point — `StartDate.Year` in the type itself, plus birth year and culture creation year (which subtract and could go negative even with a floored start date).
- Tidied two `Government` doc comments to reference `<see cref="Map.StartDate"/>` instead of a stale `1066.1.1` literal, and deleted a stale `867/1000` culture-date comment that described a long-gone fixed-date scheme.

## Verification
- Build clean (0 errors).
- **Byte-identical** output on Oncyia `--seed 42` before/after the rewire — every text/data file matches `develop`. The only run-to-run diffs are PNGs that vary identically with *unchanged* code (pre-existing image-pipeline nondeterminism; confirmed by a same-code re-run producing the exact same diff set).
- Floors verified as no-ops at the 1066 default (earliest birth 1033; Oncyia cultures all foundational, so no `created=` dates emitted).

## Caveat
The culture-creation-date floor path isn't exercised by Oncyia (no derived cultures), so that `Math.Max(0, …)` is logic-verified but not output-verified against a derived-culture map.

## Out of scope (deferred follow-up)
Reading the start date from Azgaar; month/day support beyond `.1.1`; replacing the flat `RulerAgeOffset` with the age curve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)