### PR TITLE
Add --animate-duchy: barony-growth and county-formation process GIFs

### DIFF
--- a/ConsoleUI/Program.cs
+++ b/ConsoleUI/Program.cs
@@ -12,7 +12,8 @@ internal class Program
         int? minDuchiesPerKingdom = null, int? minKingdomsPerEmpire = null,
         bool noRivers = false, bool noWipe = false, string? svgPath = null, string? inputDir = null,
         int? seed = null, int? tenetCount = null, float? doctrineMutationRate = null, string? outputDir = null,
-        string? dumpCellsPath = null, bool riversOnly = false, bool? generateDebugImages = null)
+        string? dumpCellsPath = null, bool riversOnly = false, bool? generateDebugImages = null,
+        int? animateDuchyId = null)
     {
         Logger.Title();
 
@@ -66,6 +67,11 @@ internal class Program
         {
             Settings.Instance.MinimumKingdomsPerEmpire = minKingdomsPerEmpire.Value;
             Logger.Info($"Minimum kingdoms per empire: {minKingdomsPerEmpire.Value}");
+        }
+        if (animateDuchyId.HasValue)
+        {
+            Settings.Instance.AnimateDuchyId = animateDuchyId.Value;
+            Logger.Info($"Animate duchy: {animateDuchyId.Value} (process GIFs only; pipeline exits after county formation)");
         }
         if (seed.HasValue)
             Settings.Instance.Seed = seed.Value;
@@ -172,6 +178,14 @@ internal class Program
             await Converter.Lemur.ConversionManager.DrawRiversOnly(noRivers);
             return;
         }
+        // --animate-duchy: run the pipeline through county formation, write process GIFs, exit.
+        // ConversionManager.Run() detects AnimateDuchyId and returns after rendering the GIFs.
+        if (Settings.Instance.AnimateDuchyId.HasValue)
+        {
+            SettingsManager.Configure();
+            await Converter.Lemur.ConversionManager.Run(noRivers);
+            return;
+        }
 
         Console.Write("Start conversion? ");
         bool conversionRan = false;
@@ -238,6 +252,7 @@ internal class Program
             bool noRivers = false;
             bool noWipe = false;
             bool riversOnly = false;
+            int? animateDuchyId = null;
             bool? empireFromCulture = null;
             int? minDuchiesPerKingdom = null;
             int? minKingdomsPerEmpire = null;
@@ -272,6 +287,11 @@ internal class Program
                 else if (args[i] == "--rivers-only")
                 {
                     riversOnly = true;
+                }
+                else if (args[i] == "--animate-duchy" && i + 1 < args.Length)
+                {
+                    animateDuchyId = int.Parse(args[i + 1]);
+                    i++; // Skip the next argument
                 }
                 else if ((args[i] == "--input-dir" || args[i] == "-d") && i + 1 < args.Length)
                 {
@@ -453,7 +473,7 @@ internal class Program
                 return;
             }
 
-            await Run(jsonPath, geojsonPath, riversGeojsonPath, logLevel, empireFromCulture, minDuchiesPerKingdom, minKingdomsPerEmpire, noRivers, noWipe, svgPath, inputDir, seed, tenetCount, doctrineMutationRate, outputDir, dumpCellsPath, riversOnly, generateDebugImages);
+            await Run(jsonPath, geojsonPath, riversGeojsonPath, logLevel, empireFromCulture, minDuchiesPerKingdom, minKingdomsPerEmpire, noRivers, noWipe, svgPath, inputDir, seed, tenetCount, doctrineMutationRate, outputDir, dumpCellsPath, riversOnly, generateDebugImages, animateDuchyId);
         }
         catch (Exception ex)
         {
@@ -574,6 +594,8 @@ internal class Program
         Console.WriteLine("Conversion Options:");
         Console.WriteLine("  --no-rivers                      Skip river drawing; write a blank rivers.png (runtime only, not saved)");
         Console.WriteLine("  --rivers-only                    Draw only rivers.png and exit (skips the rest of the pipeline; fast iteration)");
+        Console.WriteLine("  --animate-duchy <id>             Render two process GIFs (barony growth + county formation) for one duchy");
+        Console.WriteLine("                                   (Azgaar province id) to the debug folder, then exit. Debug/illustration only.");
         Console.WriteLine("  --svg, -s <path>                 Path to Azgaar SVG export for flatmap.dds (optional; fallback uses cell biome colors)");
         Console.WriteLine("  --log-level <verbose|debug|info|warning|error>  Set log verbosity (default: info)");
         Console.WriteLine("  --generate-debug-images <bool>   Override settings.json GenerateDebugImages (true/false); the setting is the default");

--- a/Converter/Lemur/ConversionManager.cs
+++ b/Converter/Lemur/ConversionManager.cs
@@ -959,10 +959,8 @@ namespace Converter.Lemur
                     : null;
 
                 //partition the graph into connected components
+                // (onStep captures one county frame per step, incl. the single-partition early return)
                 var partitions = Graph.PartitionGraph(graph, onStep);
-
-                // Guarantee a final, complete frame even if PartitionGraph returned early (single partition).
-                if (animateCounty) DuchyAnimator.CaptureCountyFrame(partitions, nodeToBarony!);
 
                 //Each partition is a county, so nearly there. First we translate back from graphs to baronies
                 var counties = new List<County>();

--- a/Converter/Lemur/ConversionManager.cs
+++ b/Converter/Lemur/ConversionManager.cs
@@ -195,6 +195,14 @@ namespace Converter.Lemur
             GenerateBaronyAdjacency(map);
             GenerateCounties(map);
 
+            // --animate-duchy: the GIFs only need the territory up to county formation. Render and exit
+            // before the (expensive) writers run — this is a debug/illustration mode, not a real conversion.
+            if (Settings.Instance.AnimateDuchyId.HasValue)
+            {
+                await DuchyAnimator.RenderAsync(map);
+                return;
+            }
+
             using (var _ = OperationTimer.Start("HolySiteFactory.Build")) map.HolySites = HolySiteFactory.Build(map);
             Logger.Info($"Built {map.HolySites.Count} holy sites.");
 
@@ -621,6 +629,10 @@ namespace Converter.Lemur
                     .OrderByDescending(b => b!.burg!.Population)
                     .ToList();
 
+                // Only one duchy can match, so capturing into the (static) animator from this
+                // parallel branch is single-threaded for that duchy — no extra locking needed.
+                bool animate = DuchyAnimator.IsTarget(duchy);
+
                 // O(1) duchy-local cell lookup — prevents cross-duchy frontier expansion
                 var duchyCells = allCells.ToDictionary(c => c.Id);
 
@@ -646,6 +658,9 @@ namespace Converter.Lemur
                             pq.Enqueue(nc, b.burg.Cell.DistanceSquared(nc));
                     return (barony: b, frontier: pq);
                 }).ToList();
+
+                // Initial frame: just the burg seed cells, before any outward growth.
+                if (animate) DuchyAnimator.CaptureGrowthFrame(baronies!);
 
                 // Multi-source Voronoi expansion: each barony claims one nearest cell per round
                 while (unassigned.Count > 0)
@@ -703,6 +718,9 @@ namespace Converter.Lemur
                             if (unassigned.Contains(nId) && duchyCells.TryGetValue(nId, out var nc))
                                 closestFrontier.Enqueue(nc, closestBarony.burg.Cell!.DistanceSquared(nc));
                     }
+
+                    // One frame per expansion round.
+                    if (animate) DuchyAnimator.CaptureGrowthFrame(baronies!);
                 }
 
                 if (Settings.Instance.LogLevel <= LogLevel.Info && unassigned.Count > 0)
@@ -931,8 +949,20 @@ namespace Converter.Lemur
                     //add the edge to the graph
                     graph.AddEdge(baronyNode.Node, adjacentNodes);
                 }
+                // For the animated duchy, snapshot each partitioning step into the animator.
+                bool animateCounty = DuchyAnimator.IsTarget(duchy);
+                Dictionary<Node, Barony>? nodeToBarony = animateCounty
+                    ? baronyNodes.ToDictionary(bn => bn.Node, bn => bn.Barony)
+                    : null;
+                Action<IReadOnlyList<Graph>>? onStep = animateCounty
+                    ? parts => DuchyAnimator.CaptureCountyFrame(parts, nodeToBarony!)
+                    : null;
+
                 //partition the graph into connected components
-                var partitions = Graph.PartitionGraph(graph);
+                var partitions = Graph.PartitionGraph(graph, onStep);
+
+                // Guarantee a final, complete frame even if PartitionGraph returned early (single partition).
+                if (animateCounty) DuchyAnimator.CaptureCountyFrame(partitions, nodeToBarony!);
 
                 //Each partition is a county, so nearly there. First we translate back from graphs to baronies
                 var counties = new List<County>();

--- a/Converter/Lemur/DuchyAnimator.cs
+++ b/Converter/Lemur/DuchyAnimator.cs
@@ -98,7 +98,6 @@ namespace Converter.Lemur
 
             var coords = map.JsonMap.mapCoordinates;
             var bbox = ComputeBounds(cells, coords);
-            var safeName = Helper.ToCk3Id("d", duchy.Name, duchy.Id); // already filesystem-safe-ish
             var idTag = $"d{duchy.Id}";
 
             var growthPath = await WriteGifAsync(

--- a/Converter/Lemur/DuchyAnimator.cs
+++ b/Converter/Lemur/DuchyAnimator.cs
@@ -1,0 +1,348 @@
+using ImageMagick;
+using Converter.Lemur.Entities;
+using Converter.Lemur.Graphs;
+
+namespace Converter.Lemur
+{
+    /// <summary>
+    /// Captures the two territory-synthesis steps for a single duchy and renders them as
+    /// animated GIFs: (1) barony growth (multi-source Voronoi cell claiming) and
+    /// (2) county formation (graph partitioning of baronies). Active only when
+    /// <see cref="Settings.AnimateDuchyId"/> is set via the <c>--animate-duchy</c> flag;
+    /// in that mode the pipeline runs just far enough to form the duchy's counties, then
+    /// <see cref="RenderAsync"/> writes the GIFs to the debug folder and the run exits.
+    ///
+    /// This is a debug/illustration tool — it does not affect normal conversions.
+    /// </summary>
+    public static class DuchyAnimator
+    {
+        // Cumulative full-state snapshots (cellId -> fill colour), one per algorithm step.
+        private static readonly List<Dictionary<int, MagickColor>> _growthFrames = new();
+        private static readonly List<Dictionary<int, MagickColor>> _countyFrames = new();
+        private static Dictionary<Barony, MagickColor>? _baronyPalette;
+
+        private static readonly MagickColor Unassigned = new MagickColor("#C8C8C8"); // light grey
+        private const int TargetWidth = 820; // upscale small duchy crops to at least this width
+
+        /// <summary>True when the given duchy is the one selected for animation.</summary>
+        public static bool IsTarget(Duchy duchy) =>
+            Settings.Instance.AnimateDuchyId.HasValue && Settings.Instance.AnimateDuchyId.Value == duchy.Id;
+
+        // ----------------------------------------------------------------- capture
+
+        /// <summary>
+        /// Snapshot the current barony cell assignment as one growth frame.
+        /// Call after seeding and after every Voronoi round.
+        /// </summary>
+        public static void CaptureGrowthFrame(IReadOnlyList<Barony> baronies)
+        {
+            EnsurePalette(baronies);
+            var frame = new Dictionary<int, MagickColor>();
+            foreach (var b in baronies)
+            {
+                var colour = _baronyPalette![b];
+                foreach (var c in b.Cells)
+                    frame[c.Id] = colour;
+            }
+            _growthFrames.Add(frame);
+        }
+
+        /// <summary>
+        /// Snapshot the current partition state as one county frame. Each partition (county in
+        /// progress) gets a distinct colour; baronies not yet in any partition stay grey.
+        /// </summary>
+        public static void CaptureCountyFrame(IReadOnlyList<Graph> partitions, Dictionary<Node, Barony> nodeToBarony)
+        {
+            var frame = new Dictionary<int, MagickColor>();
+            for (int i = 0; i < partitions.Count; i++)
+            {
+                var colour = CountyColour(i);
+                foreach (var node in partitions[i].GetNodes())
+                {
+                    if (!nodeToBarony.TryGetValue(node, out var barony)) continue;
+                    foreach (var c in barony.Cells)
+                        frame[c.Id] = colour;
+                }
+            }
+            _countyFrames.Add(frame);
+        }
+
+        private static void EnsurePalette(IReadOnlyList<Barony> baronies)
+        {
+            if (_baronyPalette != null) return;
+            _baronyPalette = new Dictionary<Barony, MagickColor>();
+            for (int i = 0; i < baronies.Count; i++)
+                _baronyPalette[baronies[i]] = DistinctColour(i, Math.Max(1, baronies.Count), 0.62, 0.92);
+        }
+
+        // ----------------------------------------------------------------- render
+
+        public static async Task RenderAsync(Map map)
+        {
+            var id = Settings.Instance.AnimateDuchyId;
+            if (id == null) return;
+
+            var duchy = map.Duchies?.FirstOrDefault(d => d.Id == id.Value);
+            if (duchy == null)
+            {
+                Logger.Warning($"--animate-duchy {id}: no duchy with that id was generated. Nothing to animate.");
+                return;
+            }
+
+            var cells = duchy.GetAllCells();
+            if (cells.Count == 0)
+            {
+                Logger.Warning($"--animate-duchy {id}: duchy '{duchy.Name}' has no cells. Nothing to animate.");
+                return;
+            }
+
+            var coords = map.JsonMap.mapCoordinates;
+            var bbox = ComputeBounds(cells, coords);
+            var safeName = Helper.ToCk3Id("d", duchy.Name, duchy.Id); // already filesystem-safe-ish
+            var idTag = $"d{duchy.Id}";
+
+            var growthPath = await WriteGifAsync(
+                _growthFrames, duchy, bbox, coords,
+                title: $"Barony growth — {duchy.Name} ({idTag})",
+                legend: new[]
+                {
+                    "Each colour = one barony  •  dot = town (burg)",
+                    "Cells claimed outward from each town, nearest first",
+                },
+                drawBurgDots: true,
+                frameDelayCs: 12,
+                fileName: $"anim_1_barony_growth_{idTag}.gif");
+
+            var countyPath = await WriteGifAsync(
+                _countyFrames, duchy, bbox, coords,
+                title: $"County formation — {duchy.Name} ({idTag})",
+                legend: new[]
+                {
+                    "Each colour = one county",
+                    "Baronies grouped to balance population",
+                },
+                drawBurgDots: false,
+                frameDelayCs: 80,
+                fileName: $"anim_2_county_formation_{idTag}.gif");
+
+            Logger.Section("Duchy process animation complete");
+            if (growthPath != null) Logger.Info($"  Barony growth GIF:   {growthPath}");
+            if (countyPath != null) Logger.Info($"  County formation GIF: {countyPath}");
+        }
+
+        private static async Task<string?> WriteGifAsync(
+            List<Dictionary<int, MagickColor>> frames,
+            Duchy duchy,
+            Bounds bbox,
+            Deserialization.AzgaarMapCoordinates coords,
+            string title,
+            string[] legend,
+            bool drawBurgDots,
+            int frameDelayCs,
+            string fileName)
+        {
+            if (frames.Count == 0)
+            {
+                Logger.Warning($"DuchyAnimator: no frames captured for '{fileName}', skipping.");
+                return null;
+            }
+
+            var allCells = duchy.GetAllCells();
+            var crop = bbox.ToGeometry();
+
+            using var collection = new MagickImageCollection();
+
+            for (int fi = 0; fi < frames.Count; fi++)
+            {
+                var frame = frames[fi];
+
+                // Group cells by fill colour for this frame (grey = not yet assigned).
+                var byColour = new Dictionary<MagickColor, List<Cell>>();
+                foreach (var c in allCells)
+                {
+                    var colour = frame.TryGetValue(c.Id, out var col) ? col : Unassigned;
+                    if (!byColour.TryGetValue(colour, out var list))
+                        byColour[colour] = list = new List<Cell>();
+                    list.Add(c);
+                }
+
+                // Neutral light-grey canvas: any gaps (e.g. cells turned into wasteland, so excluded
+                // from every county) read as intentional background rather than a stark white hole,
+                // while staying distinct from the slightly darker "unassigned" cell grey.
+                var readSettings = new MagickReadSettings { Width = Entities.Map.MapWidth, Height = Entities.Map.MapHeight };
+                var img = new MagickImage("xc:#E8E8E8", readSettings);
+
+                var drawablesList = new List<Drawables>();
+                foreach (var group in byColour)
+                    drawablesList.Add(ImageUtility.GenerateCellPolygons(group.Value, group.Key, coords));
+                img.Draw(drawablesList.SelectMany(d => d));
+
+                if (drawBurgDots)
+                {
+                    var dots = new Drawables();
+                    foreach (var barony in duchy.Baronies)
+                    {
+                        var cell = barony.burg?.Cell;
+                        if (cell == null) continue;
+                        var p = Centroid(cell, coords);
+                        dots.StrokeColor(MagickColors.Black).StrokeWidth(2)
+                            .FillColor(MagickColors.White)
+                            .Circle(p.X, p.Y, p.X + 5, p.Y);
+                    }
+                    img.Draw(dots);
+                }
+
+                // Crop to the duchy, then reset the virtual canvas so every frame shares the
+                // same origin/size (otherwise Coalesce re-expands to the full map with an offset).
+                img.Crop(crop);
+                img.Page = new MagickGeometry((int)img.Width, (int)img.Height);
+
+                // Upscale small duchies (nearest-neighbour keeps crisp cell edges) so the caption
+                // text has room and the result is legible at a usable size.
+                if (img.Width < TargetWidth)
+                {
+                    img.FilterType = FilterType.Point;
+                    img.Resize(new MagickGeometry($"{TargetWidth}x"));
+                    img.Page = new MagickGeometry((int)img.Width, (int)img.Height);
+                }
+
+                DrawCaption(img, title, legend, fi + 1, frames.Count);
+
+                img.AnimationDelay = frameDelayCs;
+                collection.Add(img);
+            }
+
+            // Hold the final frame so the finished result is readable before the loop restarts.
+            collection[collection.Count - 1].AnimationDelay = 400;
+            collection[0].AnimationIterations = 0; // loop forever
+
+            collection.Coalesce();
+
+            var debugRoot = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "AzgaarToCK3", "debug");
+            var path = Helper.GetPath(debugRoot, ImageUtility.GetDebugFolderName(), fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await collection.WriteAsync(path, MagickFormat.Gif);
+            ImageUtility.RegisterGeneratedImage(path);
+            Logger.Debug($"Wrote {frames.Count}-frame GIF to '{path}'");
+            return path;
+        }
+
+        private static void DrawCaption(MagickImage img, string title, string[] legend, int step, int total)
+        {
+            int lineCount = 1 + legend.Length + 1; // title + legend + step counter
+            double fontSize = Math.Clamp(img.Width / 28.0, 13, 30);
+            double lineH = fontSize * 1.35;
+            double barH = lineH * (lineCount + 0.6);
+
+            var bar = new Drawables()
+                .FillColor(new MagickColor("#000000C0"))
+                .StrokeColor(MagickColors.Transparent)
+                .Rectangle(0, 0, img.Width, barH);
+            img.Draw(bar);
+
+            var text = new Drawables()
+                .Font("Arial")
+                .FillColor(MagickColors.White)
+                .StrokeColor(MagickColors.Transparent)
+                .TextAlignment(TextAlignment.Left);
+
+            double y = lineH;
+            text.FontPointSize(fontSize * 1.12).Text(10, y, title);
+            y += lineH;
+            text.FontPointSize(fontSize * 0.86).FillColor(new MagickColor("#DDDDDD"));
+            foreach (var line in legend)
+            {
+                text.Text(14, y, line);
+                y += lineH;
+            }
+            text.FillColor(new MagickColor("#9FE0FF")).Text(14, y, $"step {step} / {total}");
+            img.Draw(text);
+        }
+
+        private static PointD Centroid(Cell cell, Deserialization.AzgaarMapCoordinates coords)
+        {
+            double sx = 0, sy = 0;
+            int n = cell.GeoDataCoordinates.Length;
+            foreach (var pt in cell.GeoDataCoordinates)
+            {
+                var ip = Transform(pt[0], pt[1], coords);
+                sx += ip.X; sy += ip.Y;
+            }
+            return new PointD(sx / n, sy / n);
+        }
+
+        // Matches the transform in ImageUtility.GenerateCellPolygons so the crop lines up with the fill.
+        private static PointD Transform(float lon, float lat, Deserialization.AzgaarMapCoordinates coords)
+        {
+            float xOffset = coords.lonW, yOffset = coords.latS;
+            float xRatio = Entities.Map.MapWidth / coords.lonT;
+            float yRatio = Entities.Map.MapHeight / coords.latT;
+            return new PointD((lon - xOffset) * xRatio, Entities.Map.MapHeight - (lat - yOffset) * yRatio);
+        }
+
+        private static Bounds ComputeBounds(List<Cell> cells, Deserialization.AzgaarMapCoordinates coords)
+        {
+            double minX = double.MaxValue, minY = double.MaxValue, maxX = double.MinValue, maxY = double.MinValue;
+            foreach (var c in cells)
+                foreach (var pt in c.GeoDataCoordinates)
+                {
+                    var ip = Transform(pt[0], pt[1], coords);
+                    if (ip.X < minX) minX = ip.X;
+                    if (ip.Y < minY) minY = ip.Y;
+                    if (ip.X > maxX) maxX = ip.X;
+                    if (ip.Y > maxY) maxY = ip.Y;
+                }
+
+            // Pad ~6% of the larger dimension, clamped to the canvas.
+            double pad = Math.Max(24, Math.Max(maxX - minX, maxY - minY) * 0.06);
+            minX = Math.Max(0, minX - pad);
+            minY = Math.Max(0, minY - pad);
+            maxX = Math.Min(Entities.Map.MapWidth, maxX + pad);
+            maxY = Math.Min(Entities.Map.MapHeight, maxY + pad);
+            return new Bounds(minX, minY, maxX, maxY);
+        }
+
+        private readonly record struct Bounds(double MinX, double MinY, double MaxX, double MaxY)
+        {
+            public MagickGeometry ToGeometry() =>
+                new MagickGeometry((int)Math.Floor(MinX), (int)Math.Floor(MinY),
+                                   (int)Math.Ceiling(MaxX - MinX), (int)Math.Ceiling(MaxY - MinY));
+        }
+
+        // ----------------------------------------------------------------- colours
+
+        // Even hue spread for baronies (many, need to be distinguishable).
+        private static MagickColor DistinctColour(int index, int count, double sat, double val)
+        {
+            double hue = (360.0 * index) / count;
+            return FromHsv(hue, sat, val);
+        }
+
+        // Counties: golden-ratio hue walk so adjacent indices look very different even with few of them.
+        private static MagickColor CountyColour(int index)
+        {
+            double hue = (index * 137.508) % 360.0;
+            return FromHsv(hue, 0.70, 0.88);
+        }
+
+        private static MagickColor FromHsv(double h, double s, double v)
+        {
+            double c = v * s;
+            double x = c * (1 - Math.Abs((h / 60.0) % 2 - 1));
+            double m = v - c;
+            double r, g, b;
+            if (h < 60) { r = c; g = x; b = 0; }
+            else if (h < 120) { r = x; g = c; b = 0; }
+            else if (h < 180) { r = 0; g = c; b = x; }
+            else if (h < 240) { r = 0; g = x; b = c; }
+            else if (h < 300) { r = x; g = 0; b = c; }
+            else { r = c; g = 0; b = x; }
+            byte R = (byte)Math.Round((r + m) * 255);
+            byte G = (byte)Math.Round((g + m) * 255);
+            byte B = (byte)Math.Round((b + m) * 255);
+            return new MagickColor($"#{R:X2}{G:X2}{B:X2}");
+        }
+    }
+}

--- a/Converter/Lemur/Graphs/Graph.cs
+++ b/Converter/Lemur/Graphs/Graph.cs
@@ -192,7 +192,12 @@ namespace Converter.Lemur.Graphs
             //Remove any nodes that are in the partition so as only to return nodes that are adjacent to the partition
             return adjacentNodes.Where(x => !adjacencyList.ContainsKey(x)).Distinct().ToList();
         }
-        public static List<Graph> PartitionGraph(Graph graph)
+        /// <param name="onStep">
+        /// Optional observer fired after each partition is seeded and after each leftover node is
+        /// placed, receiving the current partition list. Used by DuchyAnimator to capture frames;
+        /// null (the default) in normal runs.
+        /// </param>
+        public static List<Graph> PartitionGraph(Graph graph, Action<IReadOnlyList<Graph>>? onStep = null)
         {
             // Determine the number of partitions for this graph
             int numberOfPartitions = DetermineNumberOfPartitions(graph);
@@ -263,6 +268,7 @@ namespace Converter.Lemur.Graphs
                 isolatedSmallNeighbour.InSubGraph = true;
                 // Add the partition to the list of partitions
                 partitions.Add(partition);
+                onStep?.Invoke(partitions);
 
             }
 
@@ -296,12 +302,14 @@ namespace Converter.Lemur.Graphs
                         Graph isolatedPartition = new(graph);
                         isolatedPartition.AddNodeWithEdges(node, graph.adjacencyList[node]);
                         partitions.Add(isolatedPartition);
+                        onStep?.Invoke(partitions);
                         continue;
                     }
                     // Add this node to the partition where adding it would bring the partition closest to the ideal population
                     int idealPopulation = graph.Population() / numberOfPartitions;
                     Graph targetPartition = borderingPartitions.OrderBy(x => Math.Abs(x.Population() + node.Population - idealPopulation)).First();
                     targetPartition.AddNodeWithEdges(node, graph.adjacencyList[node]);
+                    onStep?.Invoke(partitions);
                 }
 
             }

--- a/Converter/Lemur/Graphs/Graph.cs
+++ b/Converter/Lemur/Graphs/Graph.cs
@@ -206,6 +206,7 @@ namespace Converter.Lemur.Graphs
             if (numberOfPartitions == 1)
             {
                 Logger.Debug("Graph is already a single partition");
+                onStep?.Invoke([graph]);
                 return [graph];
             }
 

--- a/Converter/SettingsManager.cs
+++ b/Converter/SettingsManager.cs
@@ -69,6 +69,16 @@ public class Settings
     /// </summary>
     /// <value>The maximum number of counties, default is 5.</value>
     public int MaxCounties { get; set; } = 5;
+
+    /// <summary>
+    /// When set (via <c>--animate-duchy &lt;id&gt;</c>), the converter runs only far enough to
+    /// form the counties of the given duchy (Azgaar province id), captures the barony-growth
+    /// and county-formation steps as frames, writes two GIFs to the debug folder, and exits.
+    /// CLI-only debug tool; never persisted to settings.json.
+    /// </summary>
+    [JsonIgnore]
+    public int? AnimateDuchyId { get; set; } = null;
+
     /// <summary>
     /// If true then de jure empires will form based on culture.
     /// If false then de jure empires will form based on religion.


### PR DESCRIPTION
## What

A debug/illustration mode that makes the otherwise-opaque **county synthesis** legible. For a single duchy (Azgaar province id), it captures the two territory-synthesis steps as frames and writes two animated GIFs to the debug folder, then exits before the writers run.

```
AzgaarToCK3 --input-dir <map> --no-rivers --animate-duchy <provinceId>
```

- **`anim_1_barony_growth_<id>.gif`** — each barony claims cells outward from its town (the real multi-source Voronoi loop), one frame per round.
- **`anim_2_county_formation_<id>.gif`** — baronies grouped into population-balanced counties, one frame per partitioning step.

Both are duchy-cropped, nearest-neighbour upscaled for legibility, and carry a legend + phase caption.

## Why

The county grouping is hard to reason about from logs alone. Watching it animate — towns spreading into countryside, then merging into counties — makes the algorithm and the population-balance knobs intuitive. Useful for docs/blog visuals and for debugging odd groupings.

## How it works

- **`DuchyAnimator`** (new): frame capture + GIF assembly via Magick.NET (no new dependency). Reuses `ImageUtility.GenerateCellPolygons` so the rendering matches existing debug maps.
- **`AssignCellsToBaronies`**: snapshots one growth frame per Voronoi round, guarded by `DuchyAnimator.IsTarget(duchy)` (only the target duchy, which is single-threaded within the parallel loop — no locking needed).
- **`Graph.PartitionGraph`**: gains an optional `onStep` observer (null in normal runs); `GenerateCounties` uses it to snapshot one county frame per step.
- **`Settings.AnimateDuchyId`** (CLI-only, `[JsonIgnore]`) + `--animate-duchy <id>` flag + early-exit after county formation.

Zero impact on normal conversions: every hook is behind `AnimateDuchyId` / `onStep == null`.

## Self-review

- Removed an unused local; deduped the final county frame by firing `onStep` on the single-partition early return instead of an explicit extra capture.
- Frame buffers are static but the mode runs once per process and exits, so no reset needed.
- Cropped frames have their virtual canvas reset after crop/resize so `Coalesce` doesn't re-expand them.
- Wasteland cells (removed from a duchy after barony assignment) correctly fall outside every county; rendered as neutral background grey rather than a stark gap.

## Testing

Built clean. Ran on the Showcase map, duchy 815 (Ullheireweri, the handcrafted Republic of Ullheireweri): 10 baronies → 4 counties. Verified first and last frames of both GIFs — growth fills the whole duchy, county phase resolves to 4 clean counties. (GIFs shared with @MnTronslien out-of-band.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)